### PR TITLE
Add exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function callPromise(fn, args) {
 		function callback(err,other) {
 			if (err && !(typeof err === 'boolean')) return reject(err);
 			let args = arguments;
-			return resolve(args.length <= 1 ? args[0] : args.slice(1));
+			return resolve(args.length <= 1 ? args[0] : Array.prototype.slice.call(args,1));
 		}
 		fn.apply(null, args.concat([callback]));
 	});

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const METHODS = [
 	'chmod',
 	'chown',
 	'close',
+	'exists',
 	'fchmod',
 	'fchown',
 	'fdatasync',

--- a/index.js
+++ b/index.js
@@ -82,10 +82,10 @@ function callCallback(fn, args) {
 function callPromise(fn, args) {
 	return new Promise((resolve, reject) => {
 		// promisified callback
-		function callback(err) {
-			if (err) return reject(err);
-			let args = Array.prototype.slice.call(arguments, 1);
-			return resolve(args.length <= 1 ? args[0] : args);
+		function callback(err,other) {
+			if (err && !(typeof err === 'boolean')) return reject(err);
+			let args = arguments;
+			return resolve(args.length <= 1 ? args[0] : args.slice(1));
 		}
 		fn.apply(null, args.concat([callback]));
 	});


### PR DESCRIPTION
Hello,

I noticed that the exists() function is missing here so I thought that I might add it in as it looked quick enough. Unfortunately, I found that actually the exists() function returns a boolean directly as the single only argument to the callback so the check for error at line 84 was succeeding.

``` javascript
if (err) return reject(err);
```

I adjusted the code for this scenario to show the issue i suppose. I believe that after the stuff with the arguments still achieves the same result as 1 single arg was usually error and sliced anyway so all cases were rejecting anyways, so now the only time a single arg arrives is in this case, but i could be wrong.
